### PR TITLE
Update profileImage.js -> smaller font (Username, Tag)

### DIFF
--- a/src/Code/profileImage.js
+++ b/src/Code/profileImage.js
@@ -48,8 +48,8 @@ async function profileImage(user, options) {
   const canvas = createCanvas(885, 303);
   const ctx = canvas.getContext('2d');
 
-  const userMedida = lengthString(userName, ctx, 'Helvetica', '80');
-  const userFix = fixString(userName, ctx, 'Helvetica', '80', pixelLength);
+  const userMedida = lengthString(userName, ctx, 'Helvetica', '60');
+  const userFix = fixString(userName, ctx, 'Helvetica', '60', pixelLength);
 
   const finalUser =
     userMedida > pixelLength ? userFix + '...' : userName ? userName : '?????';
@@ -58,14 +58,14 @@ async function profileImage(user, options) {
     ? isString(options.customTag, 'customTag')
     : `#${discriminator}`;
 
-  ctx.font = '80px Helvetica';
+  ctx.font = '60px Helvetica';
   ctx.textAlign = 'left';
   ctx.fillStyle = '#FFFFFF';
   ctx.fillText(finalUser, 300, 155);
 
   const userPxWidth = ctx.measureText(finalUser).width;
 
-  ctx.font = '60px Sans';
+  ctx.font = '40px Sans';
   ctx.fillStyle = '#c7c7c7';
   ctx.fillText(tag, 300, 215);
 


### PR DESCRIPTION
If the name of a user is too long, the last letters are replaced with three dots: "..." to avoid this, you could set the font size of the username to 60px and that of the tag to 40px. An example of a name that is too long can be seen in the image below.   
https://i.imgur.com/zQdimDc.png
