### PR TITLE
New Discord Usernames Change

### DIFF
--- a/src/Code/profileImage.js
+++ b/src/Code/profileImage.js
@@ -215,7 +215,7 @@ async function genTextAndAvatar(data, options) {
   const ctx = canvas.getContext('2d');
 
   const { username, newSize } = parseUsername(
-    global_name,
+    options?.customTag ? discriminator === '0' ? `@${rawUsername}` : rawUsername : discriminator === '0' ? global_name : rawUsername,
     ctx,
     'Helvetica Bold',
     '80',

--- a/src/Code/profileImage.js
+++ b/src/Code/profileImage.js
@@ -206,6 +206,7 @@ async function genTextAndAvatar(data, options) {
     createdTimestamp,
     avatarURL,
     defaultAvatarURL,
+    global_name,
   } = data;
 
   const pixelLength = bot ? 470 : 555;
@@ -214,7 +215,7 @@ async function genTextAndAvatar(data, options) {
   const ctx = canvas.getContext('2d');
 
   const { username, newSize } = parseUsername(
-    discriminator === '0' ? `@${rawUsername}` : rawUsername,
+    global_name,
     ctx,
     'Helvetica Bold',
     '80',
@@ -228,7 +229,7 @@ async function genTextAndAvatar(data, options) {
 
   const tag = options?.customTag
     ? isString(options.customTag, 'customTag')
-    : discriminator === '0' ? '' : `#${discriminator}`;
+    : discriminator === '0' ? `@${rawUsername}` : `#${discriminator}`;
 
   ctx.font = `${newSize}px Helvetica Bold`;
   ctx.textAlign = 'left';

--- a/src/Code/profileImage.js
+++ b/src/Code/profileImage.js
@@ -214,7 +214,7 @@ async function genTextAndAvatar(data, options) {
   const ctx = canvas.getContext('2d');
 
   const { username, newSize } = parseUsername(
-    rawUsername,
+    discriminator === '0' ? `@${rawUsername}` : rawUsername,
     ctx,
     'Helvetica Bold',
     '80',
@@ -228,7 +228,7 @@ async function genTextAndAvatar(data, options) {
 
   const tag = options?.customTag
     ? isString(options.customTag, 'customTag')
-    : `#${discriminator}`;
+    : discriminator === '0' ? '' : `#${discriminator}`;
 
   ctx.font = `${newSize}px Helvetica Bold`;
   ctx.textAlign = 'left';


### PR DESCRIPTION
## Info
After Discords new username changes that removes discriminators users with this new update will have their discriminators shown as **#0** which obviously doesn't look as good.

## Fix

I've made this simple temporary solution that changes the username to your global username and the customTag to your new username, example below. 

Everything also shows as normal for people without the new username system.

## Screenshots

**Before this PR:**

![profile2](https://github.com/iAsure/discord-arts/assets/69999498/bca0927c-c338-499a-a9d7-edded3f11118)

**After this PR:**

![profile](https://github.com/iAsure/discord-arts/assets/69999498/9b52091c-1549-4a1b-983a-c6ade1f5245f)

### Feel free to make suggestions on how this could be improved further.