### PR TITLE
NEW_USERNAME bug fixed

### DIFF
--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -35,7 +35,7 @@ async function getBadges(data, options) {
       (a, b) => badgesOrder[b] - badgesOrder[a]
     );
 
-  if (data.discriminator === '0') {
+  if (data.discriminator === '0' && data.createdTimestamp / 1000 <= 1686614400) { // <---- 1686614400 = June 2023 0:00 AM GMT+000 (Username rollout was completed)
     const badge = await loadImage(
       Buffer.from(otherBadges.NEW_USERNAME, 'base64')
     );


### PR DESCRIPTION
NEW_USERNAME badge appears in users who don't have it, I fixed it comparing the user.createdTimestamp with 1686614400 (June 23 2023) which is the date when username rollout was completed.