### PR TITLE
Custom Subtitle + Username Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm i discord-arts@latest
 ```js
 profileImage(userId, {
   customTag?: string, // Text below the user
-  subtitle?: string, // Text below the custom tag
+  customSubtitle?: string, // Text below the custom tag
   customBadges?: string[], // Your own png badges (path and URL) (46x46)
   customBackground?: string, // Change the background to any image (path and URL) (885x303)
   overwriteBadges?: boolean, // Merge your badges with the discord defaults

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npm i discord-arts@latest
 
 ```js
 profileImage(userId, {
+  customUsername?: string, // Customise the username
   customTag?: string, // Text below the user
   customSubtitle?: string, // Text below the custom tag
   customBadges?: string[], // Your own png badges (path and URL) (46x46)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm i discord-arts@latest
 ```js
 profileImage(userId, {
   customTag?: string, // Text below the user
+  subtitle?: string, // Text below the custom tag
   customBadges?: string[], // Your own png badges (path and URL) (46x46)
   customBackground?: string, // Change the background to any image (path and URL) (885x303)
   overwriteBadges?: boolean, // Merge your badges with the discord defaults

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ interface rankOptions {
 
 interface profileOptions {
     customTag?: string;
-    subtitle?: string;
+    customSubtitle?: string;
     customBadges?: string[];
     customBackground?: string;
     overwriteBadges?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ interface rankOptions {
 }
 
 interface profileOptions {
+    customUsername?: string;
     customTag?: string;
     customSubtitle?: string;
     customBadges?: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ interface rankOptions {
 
 interface profileOptions {
     customTag?: string;
+    subtitle?: string;
     customBadges?: string[];
     customBackground?: string;
     overwriteBadges?: boolean;

--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -194,7 +194,7 @@ async function genTextAndAvatar(data, options, avatarData) {
     pixelLength
   );
 
-  if (options?.subtitle && !options.rankData) {
+  if (options?.customSubtitle && !options.rankData) {
     ctx.globalAlpha = alphaValue;
     ctx.fillStyle = '#2a2d33';
     ctx.beginPath();
@@ -205,7 +205,7 @@ async function genTextAndAvatar(data, options, avatarData) {
     ctx.font = '23px Helvetica';
     ctx.textAlign = 'left';
     ctx.fillStyle = options?.color ? options.color : '#dadada';
-    ctx.fillText(`${options?.subtitle}`, 314, 273);
+    ctx.fillText(`${options?.customSubtitle}`, 314, 273);
   }
 
   const createdDateString = getDateOrString(

--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -194,6 +194,20 @@ async function genTextAndAvatar(data, options, avatarData) {
     pixelLength
   );
 
+  if (options?.subtitle) {
+    ctx.globalAlpha = alphaValue;
+    ctx.fillStyle = '#2a2d33';
+    ctx.beginPath();
+    ctx.roundRect(304, 248, 380, 33, [12]);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    ctx.font = '20px Helvetica';
+    ctx.textAlign = 'left';
+    ctx.fillStyle = options?.color ? options.color : '#dadada';
+    ctx.fillText(`${options?.subtitle}`, 314, 273);
+  }
+
   const createdDateString = getDateOrString(
     options?.customDate,
     createdTimestamp,

--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -194,7 +194,7 @@ async function genTextAndAvatar(data, options, avatarData) {
     pixelLength
   );
 
-  if (options?.subtitle) {
+  if (options?.subtitle && !options.rankData) {
     ctx.globalAlpha = alphaValue;
     ctx.fillStyle = '#2a2d33';
     ctx.beginPath();

--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -184,7 +184,7 @@ async function genTextAndAvatar(data, options, avatarData) {
   let canvas = createCanvas(885, 303);
   const ctx = canvas.getContext('2d');
 
-  const fixedUsername = globalName || rawUsername;
+  const fixedUsername = options?.customUsername || globalName || rawUsername;
 
   const { username, newSize } = parseUsername(
     fixedUsername,

--- a/src/utils/profile-image.utils.js
+++ b/src/utils/profile-image.utils.js
@@ -202,7 +202,7 @@ async function genTextAndAvatar(data, options, avatarData) {
     ctx.fill();
     ctx.globalAlpha = 1;
 
-    ctx.font = '20px Helvetica';
+    ctx.font = '23px Helvetica';
     ctx.textAlign = 'left';
     ctx.fillStyle = options?.color ? options.color : '#dadada';
     ctx.fillText(`${options?.subtitle}`, 314, 273);


### PR DESCRIPTION
# Info
A couple new options that adds more space for more user customisability, the `customSubtitle` being in the same position that the rank cards xp and level would be displayed and the `customUsername` in place of where the `globalName` would typically be.

# Input
```js
await profileImage('userID', {
    customUsername: 'Welcome',
    customSubtitle: `Member Count: ${guild.memberCount}`,
});
```
# Output Card
![file](https://github.com/iAsure/discord-arts/assets/69999498/bdd71d82-5c72-48a6-a567-78ed7b0f1470)

